### PR TITLE
feat: 判定に必要な入力項目のみを条件付きで表示

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -53,7 +53,6 @@ const isRackWarehouse = ref(false);
 const ceilingHeight = ref<number | null>(null);
 const storesDesignatedCombustiblesOver1000x = ref(false);
 const hasFireSuppressingStructure = ref(false);
-const hasBeds = ref(false);
 const storesDesignatedCombustiblesOver500x = ref(false); // 令21条8号用
 const hasRoadPart = ref(false); // 令21条12号用
 const roadPartRooftopArea = ref<number | null>(null);
@@ -335,7 +334,6 @@ const { regulationResult: judgementResult12 } = useArticle12Logic({
   ceilingHeight,
   storesDesignatedCombustiblesOver1000x: storesDesignatedCombustiblesOver1000x,
   hasFireSuppressingStructure,
-  hasBeds,
 });
 
 const { regulationResult: judgementResult13 } = useArticle13Logic({
@@ -758,7 +756,6 @@ generateFloors();
                 storesDesignatedCombustiblesOver1000x
               "
               v-model:isCareDependentOccupancy="isCareDependentOccupancy"
-              v-model:hasBeds="hasBeds"
               v-model:hasStageArea="hasStageArea"
               v-model:stageFloorLevel="stageFloorLevel"
               v-model:stageArea="stageArea"

--- a/src/components/AdditionalInfoStep.vue
+++ b/src/components/AdditionalInfoStep.vue
@@ -177,6 +177,7 @@ const selectedDesignatedCombustibleLevel = computed({
       <v-divider class="my-4"></v-divider>
       <p class="font-weight-bold mb-2">令第12条（スプリンクラー設備）関連</p>
       <v-checkbox
+        v-if="useCodeMatches(buildingUse, ['annex06'])"
         :model-value="hasFireSuppressingStructure"
         @update:model-value="emit('update:hasFireSuppressingStructure', $event)"
         label="延焼抑制構造である（主要構造部が耐火構造＋開口部が防火設備など）"
@@ -305,6 +306,42 @@ const selectedDesignatedCombustibleLevel = computed({
             label="駐車するすべての車両が同時に屋外に出られる構造の階である"
             hide-details
           ></v-checkbox>
+          <v-divider class="my-4"></v-divider>
+          <v-checkbox
+            :model-value="parking.mechanical.present"
+            @update:model-value="
+              (val) =>
+                emit('update:parking', {
+                  ...parking,
+                  mechanical: { ...parking.mechanical, present: val },
+                })
+            "
+            label="機械式駐車場がある"
+            hide-details
+          ></v-checkbox>
+          <v-expand-transition>
+            <div v-if="parking.mechanical.present" class="ml-8">
+              <v-text-field
+                label="収容台数"
+                :model-value="parking.mechanical.capacity"
+                @update:model-value="
+                  (val) =>
+                    emit('update:parking', {
+                      ...parking,
+                      mechanical: {
+                        ...parking.mechanical,
+                        capacity: val === '' ? null : Number(val),
+                      },
+                    })
+                "
+                type="number"
+                min="0"
+                suffix="台"
+                dense
+                style="max-width: 200px"
+              ></v-text-field>
+            </div>
+          </v-expand-transition>
         </div>
       </v-expand-transition>
 
@@ -340,41 +377,6 @@ const selectedDesignatedCombustibleLevel = computed({
 
       <v-divider class="my-4"></v-divider>
       <p class="font-weight-bold mb-2">令第13条（水噴霧消火設備等）関連</p>
-      <v-checkbox
-        :model-value="parking.mechanical.present"
-        @update:model-value="
-          (val) =>
-            emit('update:parking', {
-              ...parking,
-              mechanical: { ...parking.mechanical, present: val },
-            })
-        "
-        label="機械式駐車場がある"
-        hide-details
-      ></v-checkbox>
-      <v-expand-transition>
-        <div v-if="parking.mechanical.present" class="ml-8">
-          <v-text-field
-            label="収容台数"
-            :model-value="parking.mechanical.capacity"
-            @update:model-value="
-              (val) =>
-                emit('update:parking', {
-                  ...parking,
-                  mechanical: {
-                    ...parking.mechanical,
-                    capacity: val === '' ? null : Number(val),
-                  },
-                })
-            "
-            type="number"
-            min="0"
-            suffix="台"
-            dense
-            style="max-width: 200px"
-          ></v-text-field>
-        </div>
-      </v-expand-transition>
       <v-checkbox
         :model-value="article13_hasCarRepairArea"
         @update:model-value="emit('update:article13_hasCarRepairArea', $event)"

--- a/src/components/BuildingInfoStep.vue
+++ b/src/components/BuildingInfoStep.vue
@@ -318,7 +318,8 @@ const emit = defineEmits([
         </v-col>
       </v-row>
       <v-row align="center">
-        <v-col cols="12" sm="3">
+        <!-- 敷地面積: 令第27条第1号で使用（敷地面積20,000㎡以上 かつ 構造基準面積以上） -->
+        <v-col cols="12" sm="3" v-if="(totalFloorAreaInput ?? 0) >= 5000">
           <v-text-field
             label="敷地面積"
             :model-value="siteArea"
@@ -332,7 +333,8 @@ const emit = defineEmits([
             hide-details
           ></v-text-field>
         </v-col>
-        <v-col cols="12" sm="3">
+        <!-- 建物の高さ: 令第27条第2号で使用（高さ31m超 かつ 延べ面積25,000㎡以上） -->
+        <v-col cols="12" sm="3" v-if="(totalFloorAreaInput ?? 0) >= 25000">
           <v-text-field
             label="建物の高さ"
             :model-value="buildingHeight"

--- a/src/components/BuildingInfoStep.vue
+++ b/src/components/BuildingInfoStep.vue
@@ -44,8 +44,6 @@ defineProps({
   hasMultipleBuildingsOnSite: { type: Boolean, required: true },
   // 介護等で避難困難な人がいるか
   isCareDependentOccupancy: { type: Boolean, required: true },
-  // 診療所にベッドがあるか
-  hasBeds: { type: Boolean, required: true },
   // 宿泊の有無
   hasLodging: { type: Boolean, required: true },
   // 舞台部の有無
@@ -81,7 +79,6 @@ const emit = defineEmits([
   "update:buildingStructure",
   "update:hasMultipleBuildingsOnSite",
   "update:isCareDependentOccupancy",
-  "update:hasBeds",
   "update:hasLodging",
   "update:hasStageArea",
   "update:stageFloorLevel",
@@ -159,13 +156,6 @@ const emit = defineEmits([
                 emit('update:isCareDependentOccupancy', $event)
               "
               label="介助がなければ避難できない者を主として入所させる施設"
-              hide-details
-            ></v-checkbox>
-            <v-checkbox
-              v-if="useCodeMatches(buildingUse, ['annex06_i_2'])"
-              :model-value="hasBeds"
-              @update:model-value="emit('update:hasBeds', $event)"
-              label="診療所にベッドがある"
               hide-details
             ></v-checkbox>
             <!-- hasLodging は 6項ハ の用途コードのときのみ表示 -->

--- a/src/components/BuildingInfoStep.vue
+++ b/src/components/BuildingInfoStep.vue
@@ -162,6 +162,7 @@ const emit = defineEmits([
               hide-details
             ></v-checkbox>
             <v-checkbox
+              v-if="useCodeMatches(buildingUse, ['annex06_i_2'])"
               :model-value="hasBeds"
               @update:model-value="emit('update:hasBeds', $event)"
               label="診療所にベッドがある"
@@ -192,9 +193,7 @@ const emit = defineEmits([
               <div v-if="hasStageArea" class="ml-8">
                 <v-radio-group
                   :model-value="stageFloorLevel"
-                  @update:model-value="
-                    emit('update:stageFloorLevel', $event)
-                  "
+                  @update:model-value="emit('update:stageFloorLevel', $event)"
                   label="舞台部のある階"
                 >
                   <v-radio
@@ -302,10 +301,7 @@ const emit = defineEmits([
             hide-details
           >
             <v-radio label="特定主要構造部が耐火構造" value="A"></v-radio>
-            <v-radio
-              label="その他の耐火構造 or 準耐火構造"
-              value="B"
-            ></v-radio>
+            <v-radio label="その他の耐火構造 or 準耐火構造" value="B"></v-radio>
             <v-radio label="その他" value="C"></v-radio>
           </v-radio-group>
         </v-col>
@@ -327,10 +323,7 @@ const emit = defineEmits([
             label="敷地面積"
             :model-value="siteArea"
             @update:model-value="
-              emit(
-                'update:siteArea',
-                $event === '' ? null : Number($event)
-              )
+              emit('update:siteArea', $event === '' ? null : Number($event))
             "
             type="number"
             min="0"
@@ -384,9 +377,7 @@ const emit = defineEmits([
       </v-row>
       <v-row class="mt-4" align="center">
         <v-col cols="12" sm="6">
-          <p class="font-weight-bold mb-2">
-            令第22条（漏電火災警報器）関連
-          </p>
+          <p class="font-weight-bold mb-2">令第22条（漏電火災警報器）関連</p>
           <v-checkbox
             :model-value="hasSpecialCombustibleStructure"
             @update:model-value="
@@ -396,7 +387,7 @@ const emit = defineEmits([
             hide-details
           ></v-checkbox>
         </v-col>
-        <v-col cols="12" sm="6">
+        <v-col v-if="hasSpecialCombustibleStructure" cols="12" sm="6">
           <v-text-field
             class="mt-4"
             label="契約電流容量"

--- a/src/components/BuildingInputStepper.vue
+++ b/src/components/BuildingInputStepper.vue
@@ -55,8 +55,6 @@ const props = defineProps({
   storesDesignatedCombustiblesOver1000x: { type: Boolean, required: true },
   // isCareDependentOccupancy: 介護等で避難困難な人がいるか。article12 で使用
   isCareDependentOccupancy: { type: Boolean, required: true },
-  // hasBeds: 診療所にベッドがあるか。article12 で使用
-  hasBeds: { type: Boolean, required: true },
   // hasStageArea: 舞台部の有無。article12 / article28 等で使用
   hasStageArea: { type: Boolean, required: true },
   // stageFloorLevel: 舞台の階種別。article12 / article28 の判定で使用
@@ -183,7 +181,6 @@ const emit = defineEmits([
   "update:hasFireSuppressingStructure",
   "update:storesDesignatedCombustiblesOver1000x",
   "update:isCareDependentOccupancy",
-  "update:hasBeds",
   "update:hasStageArea",
   "update:stageFloorLevel",
   "update:stageArea",
@@ -259,11 +256,7 @@ watch(
         editable
       ></v-stepper-item>
       <v-divider></v-divider>
-      <v-stepper-item
-        title="追加情報"
-        :value="4"
-        editable
-      ></v-stepper-item>
+      <v-stepper-item title="追加情報" :value="4" editable></v-stepper-item>
     </v-stepper-header>
 
     <v-stepper-window>
@@ -282,7 +275,6 @@ watch(
           :buildingStructure="buildingStructure"
           :hasMultipleBuildingsOnSite="hasMultipleBuildingsOnSite"
           :isCareDependentOccupancy="isCareDependentOccupancy"
-          :hasBeds="hasBeds"
           :hasLodging="hasLodging"
           :hasStageArea="hasStageArea"
           :stageFloorLevel="stageFloorLevel"
@@ -312,7 +304,6 @@ watch(
           @update:isCareDependentOccupancy="
             emit('update:isCareDependentOccupancy', $event)
           "
-          @update:hasBeds="emit('update:hasBeds', $event)"
           @update:hasLodging="emit('update:hasLodging', $event)"
           @update:hasStageArea="emit('update:hasStageArea', $event)"
           @update:stageFloorLevel="emit('update:stageFloorLevel', $event)"
@@ -346,7 +337,9 @@ watch(
           :nonFloorAreaValue="nonFloorAreaValue"
           :nonFloorAreaComponentUses="nonFloorAreaComponentUses"
           @update:floors="emit('update:floors', $event)"
-          @update:nonFloorAreaComponentUses="emit('update:nonFloorAreaComponentUses', $event)"
+          @update:nonFloorAreaComponentUses="
+            emit('update:nonFloorAreaComponentUses', $event)
+          "
         />
       </v-stepper-window-item>
 

--- a/src/composables/articles/article12Logic.ts
+++ b/src/composables/articles/article12Logic.ts
@@ -21,7 +21,6 @@ type JudgementContext = {
   ceilingHeight: number;
   storesDesignatedCombustiblesOver1000x: boolean;
   hasFireSuppressingStructure: boolean;
-  hasBeds: boolean;
 
   isSection: boolean; // 第九条適用（みなし判定）かどうか
   basisSuffix: string; // 根拠条文に付記する文字列
@@ -32,15 +31,13 @@ type JudgementContext = {
  */
 function checkItem1(ctx: JudgementContext): JudgementResult | null {
   if (!ctx.hasFireSuppressingStructure) {
-    // イ: (6)項イ(1)及び(2)
+    // イ: (6)項イ(1)及び(2) - 用途コードで有床診療所かどうかを判定
     if (useCodeMatches(ctx.useCode, ["annex06_i_1", "annex06_i_2"])) {
-      if (!(ctx.useCode.startsWith("annex06_i_2") && !ctx.hasBeds)) {
-        return {
-          required: true,
-          message: `用途（${ctx.useDisplay}）で、延焼抑制構造でないため、設置が必要です。`,
-          basis: `令第12条第1項第1号イ${ctx.basisSuffix}`,
-        };
-      }
+      return {
+        required: true,
+        message: `用途（${ctx.useDisplay}）で、延焼抑制構造でないため、設置が必要です。`,
+        basis: `令第12条第1項第1号イ${ctx.basisSuffix}`,
+      };
     }
     // ロ: (6)項ロ(1)及び(3)
     if (useCodeMatches(ctx.useCode, ["annex06_ro_1", "annex06_ro_3"])) {
@@ -371,7 +368,6 @@ export function useArticle12Logic(userInput: Article12UserInput) {
       storesDesignatedCombustiblesOver1000x:
         userInput.storesDesignatedCombustiblesOver1000x.value,
       hasFireSuppressingStructure: userInput.hasFireSuppressingStructure.value,
-      hasBeds: userInput.hasBeds.value,
       isSection: false,
       basisSuffix: "",
     };
@@ -429,7 +425,6 @@ export function useArticle12Logic(userInput: Article12UserInput) {
           storesDesignatedCombustiblesOver1000x: false,
           hasFireSuppressingStructure:
             userInput.hasFireSuppressingStructure.value, // 建物全体の構造を使用
-          hasBeds: false,
           isSection: true,
           basisSuffix: "（令第九条適用）",
         };

--- a/src/composables/articles/article13Logic.ts
+++ b/src/composables/articles/article13Logic.ts
@@ -1,45 +1,284 @@
 import { computed } from "vue";
 import { useCodeMatches } from "@/composables/utils";
-import type { JudgementResult, Article13UserInput } from "@/types";
+import type { JudgementResult, Article13UserInput, Parking } from "@/types";
+
+/**
+ * 駐車場関連の判定コンテキスト
+ */
+type ParkingContext = {
+  exists: boolean;
+  rooftopArea: number;
+  basementOrUpperArea: number;
+  firstFloorArea: number;
+  canAllVehiclesExitSimultaneously: boolean;
+  mechanicalPresent: boolean;
+  mechanicalCapacity: number;
+};
+
+/**
+ * 第1号: (13)項ロ（航空機格納庫）
+ */
+function checkItem1(useCode: string): JudgementResult | null {
+  if (useCodeMatches(useCode, ["annex13_ro"])) {
+    return {
+      required: true,
+      message:
+        "航空機格納庫（(13)項ロ）には、泡消火設備又は粉末消火設備の設置が必要です。",
+      basis: "令第13条第1項第1号",
+    };
+  }
+  return null;
+}
+
+/**
+ * 第2号: ヘリポート
+ */
+function checkItem2(hasHelicopterLandingZone: boolean): JudgementResult | null {
+  if (hasHelicopterLandingZone) {
+    return {
+      required: true,
+      message:
+        "屋上のヘリポートには、泡消火設備又は粉末消火設備の設置が必要です。",
+      basis: "令第13条第1項第2号",
+    };
+  }
+  return null;
+}
+
+/**
+ * 第3号: 道路の用に供される部分
+ */
+function checkItem3(
+  hasRoadPart: boolean,
+  rooftopArea: number | null,
+  otherArea: number | null
+): JudgementResult | null {
+  if (!hasRoadPart) return null;
+
+  // 面積が入力されている場合は、その値で判定
+  if (rooftopArea !== null || otherArea !== null) {
+    if ((rooftopArea ?? 0) >= 600 || (otherArea ?? 0) >= 400) {
+      return {
+        required: true,
+        message:
+          "道路の用に供される部分で、屋上部分が600㎡以上またはその他の部分が400㎡以上のため、水噴霧、泡、不活性ガス、粉末のいずれかの消火設備の設置が必要です。",
+        basis: "令第13条第1項第3号",
+      };
+    }
+    // 面積が入力されていて、条件未満の場合は不要（basisは条文番号を維持）
+    return {
+      required: false,
+      message:
+        "道路の用に供される部分は、面積が条件未満のため、設置義務はありません。",
+      basis: "令第13条第1項第3号",
+    };
+  }
+
+  // 面積が入力されていない場合は警告
+  return {
+    required: "warning",
+    message:
+      "【要確認】道路の用に供される部分がある場合、屋上部分で600㎡以上、その他の部分で400㎡以上の場合は、水噴霧、泡、不活性ガス、粉末のいずれかの消火設備の設置が必要です。面積を入力してください。",
+    basis: "令第13条第1項第3号",
+  };
+}
+
+/**
+ * 第4号: 自動車の修理・整備工場
+ */
+function checkItem4(
+  hasCarRepairArea: boolean,
+  basementOrUpperArea: number | null,
+  firstFloorArea: number | null
+): JudgementResult | null {
+  if (!hasCarRepairArea) return null;
+
+  // 面積が入力されている場合は、その値で判定
+  if (basementOrUpperArea !== null || firstFloorArea !== null) {
+    if ((basementOrUpperArea ?? 0) >= 200 || (firstFloorArea ?? 0) >= 500) {
+      return {
+        required: true,
+        message:
+          "自動車の修理・整備の用に供される部分で、地階・2階以上で200㎡以上または1階で500㎡以上のため、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
+        basis: "令第13条第1項第4号",
+      };
+    }
+    // 面積が入力されていて、条件未満の場合は不要（basisは条文番号を維持）
+    return {
+      required: false,
+      message:
+        "自動車の修理・整備の用に供される部分は、面積が条件未満のため、設置義務はありません。",
+      basis: "令第13条第1項第4号",
+    };
+  }
+
+  // 面積が入力されていない場合は警告
+  return {
+    required: "warning",
+    message:
+      "【要確認】自動車の修理・整備の用に供される部分がある場合、地階・2階以上で200㎡以上、1階で500㎡以上の場合は、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。面積を入力してください。",
+    basis: "令第13条第1項第4号",
+  };
+}
+
+/**
+ * 第5号イ: 駐車場（面積基準）
+ */
+function checkItem5_i(ctx: ParkingContext): JudgementResult | null {
+  if (!ctx.exists) return null;
+
+  // 駐車するすべての車両が同時に屋外に出られる構造の場合は面積判定から除外
+  const canAllExit = ctx.canAllVehiclesExitSimultaneously;
+  const rooftopApplies = !canAllExit && ctx.rooftopArea >= 300;
+  const basementOrUpperApplies = !canAllExit && ctx.basementOrUpperArea >= 200;
+  const firstFloorApplies = !canAllExit && ctx.firstFloorArea >= 500;
+
+  if (rooftopApplies || basementOrUpperApplies || firstFloorApplies) {
+    return {
+      required: true,
+      message:
+        "駐車の用に供される部分があり、階や面積が該当するため、水噴霧、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
+      basis: "令第13条第1項第5号イ",
+    };
+  }
+
+  // 駐車場が存在するが面積条件未達の場合は警告
+  return {
+    required: "warning",
+    message:
+      "【要確認】駐車の用に供される部分がある場合、階や構造、面積によって水噴霧、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です（令第13条第1項第5号イ）。",
+    basis: "令第13条第1項第5号イ",
+  };
+}
+
+/**
+ * 第5号ロ: 機械式駐車場
+ */
+function checkItem5_ro(ctx: ParkingContext): JudgementResult | null {
+  if (!ctx.mechanicalPresent) return null;
+
+  if (ctx.mechanicalCapacity >= 10) {
+    return {
+      required: true,
+      message:
+        "機械式駐車場で収容台数が10台以上のため、水噴霧、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
+      basis: "令第13条第1項第5号ロ",
+    };
+  }
+
+  return {
+    required: "warning",
+    message:
+      "【要確認】機械式駐車場の場合、収容台数が10台以上であれば、水噴霧、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
+    basis: "令第13条第1項第5号ロ",
+  };
+}
+
+/**
+ * 第6号: 電気設備（200㎡以上）
+ */
+function checkItem6(
+  hasElectricalEquipmentOver200sqm: boolean
+): JudgementResult | null {
+  if (hasElectricalEquipmentOver200sqm) {
+    return {
+      required: true,
+      message:
+        "発電機、変圧器等の電気設備が設置されている部分で、面積が200㎡以上のため、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
+      basis: "令第13条第1項第6号",
+    };
+  }
+  return null;
+}
+
+/**
+ * 第7号: 多量の火気を使用する部分（200㎡以上）
+ */
+function checkItem7(
+  hasHighFireUsageAreaOver200sqm: boolean
+): JudgementResult | null {
+  if (hasHighFireUsageAreaOver200sqm) {
+    return {
+      required: true,
+      message:
+        "鍛造場、ボイラー室、乾燥室等で、面積が200㎡以上のため、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
+      basis: "令第13条第1項第7号",
+    };
+  }
+  return null;
+}
+
+/**
+ * 第8号: 通信機器室（500㎡以上）
+ */
+function checkItem8(hasTelecomRoomOver500sqm: boolean): JudgementResult | null {
+  if (hasTelecomRoomOver500sqm) {
+    return {
+      required: true,
+      message:
+        "通信機器室で、面積が500㎡以上の場合は、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
+      basis: "令第13条第1項第8号",
+    };
+  }
+  return null;
+}
+
+/**
+ * 第9号: 指定可燃物
+ */
+function checkItem9(
+  storesDesignatedCombustiblesOver1000x: boolean
+): JudgementResult | null {
+  if (storesDesignatedCombustiblesOver1000x) {
+    return {
+      required: true,
+      message:
+        "指定可燃物を1000倍以上貯蔵・取り扱っている場合、可燃物の種類に応じて、水噴霧、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。スプリンクラー設備が設置されている場合は免除されることがあります。",
+      basis: "令第13条第1項第9号、同条第2項",
+    };
+  }
+  return null;
+}
+
+/**
+ * Parking情報からParkingContextを生成
+ */
+function createParkingContext(
+  parking: { value: Parking } | undefined,
+  legacyHasParkingArea?: { value: boolean },
+  legacyHasMechanicalParking?: { value: boolean },
+  legacyMechanicalParkingCapacity?: { value: number | null }
+): ParkingContext {
+  if (parking) {
+    const p = parking.value;
+    const mechanical = p.mechanical ?? { present: false, capacity: null };
+    return {
+      exists: p.exists,
+      rooftopArea: p.rooftopArea ?? 0,
+      basementOrUpperArea: p.basementOrUpperArea ?? 0,
+      firstFloorArea: p.firstFloorArea ?? 0,
+      canAllVehiclesExitSimultaneously:
+        p.canAllVehiclesExitSimultaneously ?? false,
+      mechanicalPresent: mechanical.present ?? false,
+      mechanicalCapacity: mechanical.capacity ?? 0,
+    };
+  }
+
+  // Legacy fallback
+  return {
+    exists: Boolean(legacyHasParkingArea?.value),
+    rooftopArea: 0,
+    basementOrUpperArea: 0,
+    firstFloorArea: 0,
+    canAllVehiclesExitSimultaneously: false,
+    mechanicalPresent: Boolean(legacyHasMechanicalParking?.value),
+    mechanicalCapacity: legacyMechanicalParkingCapacity?.value ?? 0,
+  };
+}
 
 export function useArticle13Logic(userInput: Article13UserInput) {
   const regulationResult = computed((): JudgementResult => {
-    const buildingUse = userInput.buildingUse;
-    const storesDesignatedCombustiblesOver1000x =
-      userInput.storesDesignatedCombustiblesOver1000x;
-    const parking = userInput.parking;
-    const hasCarRepairArea = userInput.hasCarRepairArea;
-    const carRepairAreaBasementOrUpper = userInput.carRepairAreaBasementOrUpper;
-    const carRepairAreaFirstFloor = userInput.carRepairAreaFirstFloor;
-    const hasHelicopterLandingZone = userInput.hasHelicopterLandingZone;
-    const hasHighFireUsageAreaOver200sqm =
-      userInput.hasHighFireUsageAreaOver200sqm;
-    const hasElectricalEquipmentOver200sqm =
-      userInput.hasElectricalEquipmentOver200sqm;
-    const hasTelecomRoomOver500sqm = userInput.hasTelecomRoomOver500sqm;
-    const hasRoadPart = userInput.hasRoadPart;
-    const roadPartRooftopArea = userInput.roadPartRooftopArea;
-    const roadPartOtherArea = userInput.roadPartOtherArea;
-    // Legacy optional properties (kept for compatibility in some callers/tests)
-    type BoolRef = { value: boolean };
-    type NumRef = { value: number | null };
-    const maybeHasParkingArea = (
-      userInput as unknown as {
-        hasParkingArea?: BoolRef;
-      }
-    ).hasParkingArea;
-    const maybeHasMechanicalParking = (
-      userInput as unknown as {
-        hasMechanicalParking?: BoolRef;
-      }
-    ).hasMechanicalParking;
-    const maybeMechanicalParkingCapacity = (
-      userInput as unknown as {
-        mechanicalParkingCapacity?: NumRef;
-      }
-    ).mechanicalParkingCapacity;
-
-    const use = buildingUse.value;
+    const use = userInput.buildingUse.value;
     if (!use) {
       return {
         required: false,
@@ -48,204 +287,87 @@ export function useArticle13Logic(userInput: Article13UserInput) {
       };
     }
 
-    // 1. (13)項ロに掲げる防火対象物
-    if (useCodeMatches(use, ["annex13_ro"])) {
-      return {
-        required: true,
-        message:
-          "航空機格納庫（(13)項ロ）には、泡消火設備又は粉末消火設備の設置が必要です。",
-        basis: "令第13条第1項第1号",
-      };
-    }
+    // Legacy optional properties (kept for compatibility in some callers/tests)
+    type BoolRef = { value: boolean };
+    type NumRef = { value: number | null };
+    const maybeHasParkingArea = (
+      userInput as unknown as { hasParkingArea?: BoolRef }
+    ).hasParkingArea;
+    const maybeHasMechanicalParking = (
+      userInput as unknown as { hasMechanicalParking?: BoolRef }
+    ).hasMechanicalParking;
+    const maybeMechanicalParkingCapacity = (
+      userInput as unknown as { mechanicalParkingCapacity?: NumRef }
+    ).mechanicalParkingCapacity;
 
-    // 2. ヘリポート
-    if (hasHelicopterLandingZone.value) {
-      return {
-        required: true,
-        message:
-          "屋上のヘリポートには、泡消火設備又は粉末消火設備の設置が必要です。",
-        basis: "令第13条第1項第2号",
-      };
-    }
+    // 駐車場コンテキストを生成
+    const parkingCtx = createParkingContext(
+      userInput.parking,
+      maybeHasParkingArea,
+      maybeHasMechanicalParking,
+      maybeMechanicalParkingCapacity
+    );
 
-    // 3. 道路の用に供される部分
-    if (hasRoadPart.value) {
-      const rooftopArea = roadPartRooftopArea.value ?? 0;
-      const otherArea = roadPartOtherArea.value ?? 0;
+    // 各号を順番にチェック
+    const results: JudgementResult[] = [];
 
-      // 面積が入力されている場合は、その値で判定
-      if (
-        roadPartRooftopArea.value !== null ||
-        roadPartOtherArea.value !== null
-      ) {
-        if (rooftopArea >= 600 || otherArea >= 400) {
-          return {
-            required: true,
-            message:
-              "道路の用に供される部分で、屋上部分が600㎡以上またはその他の部分が400㎡以上のため、水噴霧、泡、不活性ガス、粉末のいずれかの消火設備の設置が必要です。",
-            basis: "令第13条第1項第3号",
-          };
-        }
-        // 面積が入力されていて、条件未満の場合は不要
-        return {
-          required: false,
-          message:
-            "道路の用に供される部分は、面積が条件未満のため、設置義務はありません。",
-          basis: "令第13条第1項第3号",
-        };
-      }
+    // 第1号: 航空機格納庫
+    const r1 = checkItem1(use);
+    if (r1) return r1;
 
-      // 面積が入力されていない場合は警告
-      return {
-        required: "warning",
-        message:
-          "【要確認】道路の用に供される部分がある場合、屋上部分で600㎡以上、その他の部分で400㎡以上の場合は、水噴霧、泡、不活性ガス、粉末のいずれかの消火設備の設置が必要です。面積を入力してください。",
-        basis: "令第13条第1項第3号",
-      };
-    }
+    // 第2号: ヘリポート
+    const r2 = checkItem2(userInput.hasHelicopterLandingZone.value);
+    if (r2) return r2;
 
-    // 4. 自動車の修理・整備工場
-    if (hasCarRepairArea.value) {
-      const basementOrUpperArea = carRepairAreaBasementOrUpper.value ?? 0;
-      const firstFloorArea = carRepairAreaFirstFloor.value ?? 0;
+    // 第3号: 道路の用に供される部分
+    const r3 = checkItem3(
+      userInput.hasRoadPart.value,
+      userInput.roadPartRooftopArea.value,
+      userInput.roadPartOtherArea.value
+    );
+    if (r3?.required === true) return r3;
+    if (r3) results.push(r3);
 
-      // 面積が入力されている場合は、その値で判定
-      if (
-        carRepairAreaBasementOrUpper.value !== null ||
-        carRepairAreaFirstFloor.value !== null
-      ) {
-        if (basementOrUpperArea >= 200 || firstFloorArea >= 500) {
-          return {
-            required: true,
-            message:
-              "自動車の修理・整備の用に供される部分で、地階・2階以上で200㎡以上または1階で500㎡以上のため、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
-            basis: "令第13条第1項第4号",
-          };
-        }
-        // 面積が入力されていて、条件未満の場合は不要
-        return {
-          required: false,
-          message:
-            "自動車の修理・整備の用に供される部分は、面積が条件未満のため、設置義務はありません。",
-          basis: "令第13条第1項第4号",
-        };
-      }
+    // 第4号: 自動車の修理・整備工場
+    const r4 = checkItem4(
+      userInput.hasCarRepairArea.value,
+      userInput.carRepairAreaBasementOrUpper.value,
+      userInput.carRepairAreaFirstFloor.value
+    );
+    if (r4?.required === true) return r4;
+    if (r4) results.push(r4);
 
-      // 面積が入力されていない場合は警告
-      return {
-        required: "warning",
-        message:
-          "【要確認】自動車の修理・整備の用に供される部分がある場合、地階・2階以上で200㎡以上、1階で500㎡以上の場合は、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。面積を入力してください。",
-        basis: "令第13条第1項第4号",
-      };
-    }
+    // 第5号イ: 駐車場（面積基準）
+    const r5i = checkItem5_i(parkingCtx);
+    if (r5i?.required === true) return r5i;
+    if (r5i) results.push(r5i);
 
-    // 5. 駐車場
-    // 駐車部分（共通 parking モデル）。未定義なら legacy の hasParkingArea を参照
-    const parkingExists = parking
-      ? parking.value.exists
-      : Boolean(maybeHasParkingArea && maybeHasParkingArea.value);
+    // 第5号ロ: 機械式駐車場
+    const r5ro = checkItem5_ro(parkingCtx);
+    if (r5ro?.required === true) return r5ro;
+    if (r5ro) results.push(r5ro);
 
-    if (parkingExists) {
-      // Determine area-based thresholds per Article13 table:
-      // - 屋上部分: 300㎡以上
-      // - 地階または2階以上の階: 200㎡以上
-      // - 1階: 500㎡以上
-      // Exclusion: 階が「駐車するすべての車両が同時に屋外に出ることができる構造の階」である場合は当該階を除く
-      const rooftopArea = parking?.value.rooftopArea ?? 0;
-      const basementOrUpperArea = parking?.value.basementOrUpperArea ?? 0;
-      const firstFloorArea = parking?.value.firstFloorArea ?? 0;
-      const canAllExit =
-        parking?.value.canAllVehiclesExitSimultaneously ?? false;
+    // 第6号: 電気設備
+    const r6 = checkItem6(userInput.hasElectricalEquipmentOver200sqm.value);
+    if (r6) return r6;
 
-      // If parking floors are designed so all vehicles can exit simultaneously, those floors are excluded.
-      const rooftopApplies = !canAllExit && (rooftopArea || 0) >= 300;
-      const basementOrUpperApplies =
-        !canAllExit && (basementOrUpperArea || 0) >= 200;
-      const firstFloorApplies = !canAllExit && (firstFloorArea || 0) >= 500;
+    // 第7号: 多量の火気を使用する部分
+    const r7 = checkItem7(userInput.hasHighFireUsageAreaOver200sqm.value);
+    if (r7) return r7;
 
-      if (rooftopApplies || basementOrUpperApplies || firstFloorApplies) {
-        return {
-          required: true,
-          message:
-            "駐車の用に供される部分があり、階や面積が該当するため、水噴霧、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
-          basis: "令第13条第1項第5号イ",
-        };
-      }
+    // 第8号: 通信機器室
+    const r8 = checkItem8(userInput.hasTelecomRoomOver500sqm.value);
+    if (r8) return r8;
 
-      // If parking exists but no (non-exempt) area reaches threshold, return warning to review details
-      return {
-        required: "warning",
-        message:
-          "【要確認】駐車の用に供される部分がある場合、階や構造、面積によって水噴霧、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です（令第13条第1項第5号イ）。",
-        basis: "令第13条第1項第5号イ",
-      };
-    }
-    // mechanical parking: prefer new parking model, fallback to legacy fields
-    const mechanicalPresent = parking
-      ? parking.value.mechanical.present
-      : Boolean(maybeHasMechanicalParking && maybeHasMechanicalParking.value);
-    const mechanicalCapacity = parking
-      ? parking.value.mechanical.capacity ?? 0
-      : (maybeMechanicalParkingCapacity &&
-          maybeMechanicalParkingCapacity.value) ||
-        0;
+    // 第9号: 指定可燃物
+    const r9 = checkItem9(
+      userInput.storesDesignatedCombustiblesOver1000x.value
+    );
+    if (r9) return r9;
 
-    if (mechanicalPresent) {
-      const capacity = mechanicalCapacity;
-      if (capacity >= 10) {
-        return {
-          required: true,
-          message: `機械式駐車場で収容台数が10台以上のため、水噴霧、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。`,
-          basis: "令第13条第1項第5号ロ",
-        };
-      }
-      return {
-        required: "warning",
-        message:
-          "【要確認】機械式駐車場の場合、収容台数が10台以上であれば、水噴霧、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
-        basis: "令第13条第1項第5号ロ",
-      };
-    }
-
-    // 6. 電気設備（200㎡以上）
-    if (hasElectricalEquipmentOver200sqm.value) {
-      return {
-        required: true,
-        message:
-          "発電機、変圧器等の電気設備が設置されている部分で、面積が200㎡以上のため、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
-        basis: "令第13条第1項第6号",
-      };
-    }
-
-    // 7. 多量の火気を使用する部分（200㎡以上）
-    if (hasHighFireUsageAreaOver200sqm.value) {
-      return {
-        required: true,
-        message:
-          "鍛造場、ボイラー室、乾燥室等で、面積が200㎡以上のため、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
-        basis: "令第13条第1項第7号",
-      };
-    }
-
-    // 8. 通信機器室（500㎡以上）
-    if (hasTelecomRoomOver500sqm.value) {
-      return {
-        required: true,
-        message:
-          "通信機器室で、面積が500㎡以上の場合は、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。",
-        basis: "令第13条第1項第8号",
-      };
-    }
-
-    // 9. 指定可燃物
-    if (storesDesignatedCombustiblesOver1000x.value) {
-      return {
-        required: true,
-        message:
-          "指定可燃物を1000倍以上貯蔵・取り扱っている場合、可燃物の種類に応じて、水噴霧、泡、不活性ガス、ハロゲン化物、粉末のいずれかの消火設備の設置が必要です。スプリンクラー設備が設置されている場合は免除されることがあります。",
-        basis: "令第13条第1項第9号、同条第2項",
-      };
+    // warningがあれば最初のものを返す
+    if (results.length > 0) {
+      return results[0];
     }
 
     return {

--- a/src/tests/article12Logic.spec.ts
+++ b/src/tests/article12Logic.spec.ts
@@ -20,7 +20,6 @@ const createMockInput = (
     ceilingHeight: ref(0),
     storesDesignatedCombustiblesOver1000x: ref(false),
     hasFireSuppressingStructure: ref(false),
-    hasBeds: ref(false),
   };
 
   // Create a new object for the merged regulationResult to avoid modifying defaults

--- a/src/tests/components/BuildingInfoStep.spec.ts
+++ b/src/tests/components/BuildingInfoStep.spec.ts
@@ -29,7 +29,11 @@ describe("BuildingInfoStep.vue", () => {
     finishType: "flammable" | "other" | null;
     siteArea: number | null;
     buildingHeight: number | null;
-    buildingStructure: "fire-resistant" | "quasi-fire-resistant" | "other" | null;
+    buildingStructure:
+      | "fire-resistant"
+      | "quasi-fire-resistant"
+      | "other"
+      | null;
     hasMultipleBuildingsOnSite: boolean;
     isCareDependentOccupancy: boolean;
     hasBeds: boolean;
@@ -95,10 +99,19 @@ describe("BuildingInfoStep.vue", () => {
   // =================================================================
   // 2. 動的表示のテスト
   // =================================================================
-  it("（6）項関連の情報が正しく表示される", async () => {
+  it("（6）項ロ(2)関連の情報が正しく表示される（ベッドは表示されない）", async () => {
     await wrapper.setProps({ buildingUse: "annex06_ro_2" });
     expect(wrapper.text()).toContain("（6）項関連の追加情報");
-    expect(wrapper.text()).toContain("介助がなければ避難できない者を主として入所させる施設");
+    expect(wrapper.text()).toContain(
+      "介助がなければ避難できない者を主として入所させる施設"
+    );
+    // annex06_ro_2では「診療所にベッドがある」は表示されない（annex06_i_2のみ）
+    expect(wrapper.text()).not.toContain("診療所にベッドがある");
+  });
+
+  it("（6）項イ(2)で「診療所にベッドがある」が表示される", async () => {
+    await wrapper.setProps({ buildingUse: "annex06_i_2" });
+    expect(wrapper.text()).toContain("（6）項関連の追加情報");
     expect(wrapper.text()).toContain("診療所にベッドがある");
   });
 
@@ -119,9 +132,11 @@ describe("BuildingInfoStep.vue", () => {
   // =================================================================
   it("建物用途の変更がemitされる", async () => {
     // BuildingUseSelectorが変更された時のイベントをシミュレート
-    const buildingUseSelector = wrapper.findComponent({ name: "BuildingUseSelector" });
+    const buildingUseSelector = wrapper.findComponent({
+      name: "BuildingUseSelector",
+    });
     await buildingUseSelector.vm.$emit("update:modelValue", "annex01_i");
-    
+
     // イベントが発行されたか確認
     expect(wrapper.emitted("update:buildingUse")).toBeTruthy();
     expect(wrapper.emitted("update:buildingUse")![0]).toEqual(["annex01_i"]);

--- a/src/tests/components/BuildingInfoStep.spec.ts
+++ b/src/tests/components/BuildingInfoStep.spec.ts
@@ -36,7 +36,6 @@ describe("BuildingInfoStep.vue", () => {
       | null;
     hasMultipleBuildingsOnSite: boolean;
     isCareDependentOccupancy: boolean;
-    hasBeds: boolean;
     hasLodging: boolean;
     hasStageArea: boolean;
     stageFloorLevel: string | null;
@@ -61,7 +60,6 @@ describe("BuildingInfoStep.vue", () => {
     buildingStructure: null,
     hasMultipleBuildingsOnSite: false,
     isCareDependentOccupancy: false,
-    hasBeds: false,
     hasLodging: false,
     hasStageArea: false,
     stageFloorLevel: null,
@@ -99,20 +97,12 @@ describe("BuildingInfoStep.vue", () => {
   // =================================================================
   // 2. 動的表示のテスト
   // =================================================================
-  it("（6）項ロ(2)関連の情報が正しく表示される（ベッドは表示されない）", async () => {
+  it("（6）項ロ(2)関連の情報が正しく表示される", async () => {
     await wrapper.setProps({ buildingUse: "annex06_ro_2" });
     expect(wrapper.text()).toContain("（6）項関連の追加情報");
     expect(wrapper.text()).toContain(
       "介助がなければ避難できない者を主として入所させる施設"
     );
-    // annex06_ro_2では「診療所にベッドがある」は表示されない（annex06_i_2のみ）
-    expect(wrapper.text()).not.toContain("診療所にベッドがある");
-  });
-
-  it("（6）項イ(2)で「診療所にベッドがある」が表示される", async () => {
-    await wrapper.setProps({ buildingUse: "annex06_i_2" });
-    expect(wrapper.text()).toContain("（6）項関連の追加情報");
-    expect(wrapper.text()).toContain("診療所にベッドがある");
   });
 
   it("（1）項関連の情報が正しく表示される", async () => {

--- a/src/tests/components/BuildingInputStepper.designatedCombustible.spec.ts
+++ b/src/tests/components/BuildingInputStepper.designatedCombustible.spec.ts
@@ -29,7 +29,6 @@ describe("BuildingInputStepper - 指定可燃物ラジオのマッピング", ()
     hasFireSuppressingStructure: false,
     storesDesignatedCombustiblesOver1000x: false,
     isCareDependentOccupancy: false,
-    hasBeds: false,
     hasStageArea: false,
     stageFloorLevel: null,
     stageArea: null,

--- a/src/tests/components/BuildingInputStepper.spec.ts
+++ b/src/tests/components/BuildingInputStepper.spec.ts
@@ -39,7 +39,6 @@ describe("BuildingInputStepper.vue", () => {
     hasFireSuppressingStructure: boolean;
     storesDesignatedCombustiblesOver1000x: boolean;
     isCareDependentOccupancy: boolean;
-    hasBeds: boolean;
     hasStageArea: boolean;
     stageFloorLevel: string | null;
     stageArea: number | null;
@@ -101,7 +100,6 @@ describe("BuildingInputStepper.vue", () => {
     hasFireSuppressingStructure: false,
     storesDesignatedCombustiblesOver1000x: false,
     isCareDependentOccupancy: false,
-    hasBeds: false,
     hasStageArea: false,
     stageFloorLevel: null,
     stageArea: null,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,7 +40,6 @@ export interface Article12UserInput {
   ceilingHeight: Ref<number | null>;
   storesDesignatedCombustiblesOver1000x: Ref<boolean>;
   hasFireSuppressingStructure: Ref<boolean>;
-  hasBeds: Ref<boolean>;
 }
 
 // Article13UserInput


### PR DESCRIPTION
## 概要
判定に必要な入力フィールドのみを表示するよう、UIを改善しました。

## 変更内容

### 1. 条件付き表示の実装
- **hasBeds（診療所にベッド）**: annex06_i_2 の場合のみ → **削除**（用途コードで区分済みのため不要）
- **hasFireSuppressingStructure（延焼抑制構造）**: annex06 の場合のみ表示
- **contractedCurrentCapacity（契約電流容量）**: hasSpecialCombustibleStructure=true の場合のみ表示
- **機械式駐車場**: parking.exists の展開内に移動
- **敷地面積**: 延べ面積 5,000㎡以上の場合のみ表示（令第27条第1号用）
- **建物の高さ**: 延べ面積 25,000㎡以上の場合のみ表示（令第27条第2号用）

### 2. hasBeds プロパティの削除
用途コードが 6項イ(1)〜(4) で細分化されているため、`hasBeds`（診療所にベッドがある）フラグは冗長でした。
- annex06_i_1 = 病院
- annex06_i_2 = 有床診療所
- annex06_i_3 = 助産所（無床）
- annex06_i_4 = その他

### 3. article13Logic.ts のリファクタリング
- 機械式駐車場を parking.exists 内に移動した際に発生したバグを修正
- 各号（1号〜9号）を独立した関数に分離
- ParkingContext 型を導入してパーキング関連のプロパティを一元管理

## テスト
- 全263テストが通過